### PR TITLE
chore(frontend): otel tweaks

### DIFF
--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -94,8 +94,8 @@ export function handleError(error: unknown, { context, params, request }: Loader
     log.error('Uncaught error while handling request:', error);
 
     createCounter('server.errors.total').add(1, {
-      error_class: getErrorClassName(error),
-      error_code: getErrorCode(error),
+      'error.class': getErrorClassName(error),
+      'error.code': getErrorCode(error),
     });
 
     handleSpanException(error, trace.getActiveSpan());

--- a/frontend/containerfile
+++ b/frontend/containerfile
@@ -33,7 +33,7 @@ ARG BUILD_REVISION="00000000"
 ARG BUILD_VERSION="0.0.0"
 ARG IMAGE_AUTHORS="Digital Technology Solutions"
 ARG IMAGE_DESCRIPTION="CDB Estimator -- Frontend Application"
-ARG IMAGE_TITLE="CDB Estimator frontend"
+ARG IMAGE_TITLE="cdb-estimator-frontend"
 ARG IMAGE_URL="https://github.com/DTS-STN/cdb-estimator/"
 ARG IMAGE_VENDOR="Employment and Social Development Canada"
 


### PR DESCRIPTION
## Summary

* fix the image name in `containerfile` (this name is also used for the OpenTelemetry `service.name` dimension)
* fix the error counter's dimensions to fit more with standard dimension naming conventions

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [x] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
