### PR TITLE
fix(frontend) Correct age calculation

### DIFF
--- a/frontend/app/utils/age-utils.ts
+++ b/frontend/app/utils/age-utils.ts
@@ -9,8 +9,8 @@ import { differenceInMonths, differenceInYears } from 'date-fns';
  */
 export function calculateAge(month: number, year: number): number {
   const date = new Date(year, month - 1, 1); // Explicity set to first day of the month
-  date.setUTCHours(0, 0, 0, 0); // Set the time to midnight because we only care about the date
   date.setFullYear(year); // Ensure the year is set correctly for years < 100
+  date.setUTCHours(0, 0, 0, 0); // Set the time to midnight because we only care about the date
 
   const now = new Date();
   now.setUTCHours(0, 0, 0, 0); // Set the time to midnight because we only care about the date
@@ -27,8 +27,8 @@ export function calculateAge(month: number, year: number): number {
  */
 export function calculateAgeInMonths(month: number, year: number): number {
   const date = new Date(year, month - 1, 1); // Explicity set to first day of the month
-  date.setUTCHours(0, 0, 0, 0); // Set the time to midnight because we only care about the date
   date.setFullYear(year); // Ensure the year is set correctly for years < 100
+  date.setUTCHours(0, 0, 0, 0); // Set the time to midnight because we only care about the date
 
   const now = new Date();
   now.setUTCHours(0, 0, 0, 0); // Set the time to midnight because we only care about the date

--- a/frontend/tests/utils/age-utils.test.ts
+++ b/frontend/tests/utils/age-utils.test.ts
@@ -19,6 +19,11 @@ describe('age-utils', () => {
       expect(calculateAge(4, 1990)).toEqual(10);
     });
 
+    it('should return the correct age: 10 when at start of year', () => {
+      vi.setSystemTime(new Date('2000-01-01T05:00:00.000Z'));
+      expect(calculateAge(1, 1990)).toEqual(10);
+    });
+
     it('should return the correct age for year < 100', () => {
       vi.setSystemTime(new Date('2000-04-01'));
       expect(calculateAge(4, 10)).toEqual(1990);
@@ -49,6 +54,11 @@ describe('age-utils', () => {
     it('should return the correct age in months: 120', () => {
       vi.setSystemTime(new Date('2000-04-01'));
       expect(calculateAgeInMonths(4, 1990)).toEqual(120);
+    });
+
+    it('should return the correct age in months: 120 when at start of year', () => {
+      vi.setSystemTime(new Date('2000-01-01T05:00:00.000Z'));
+      expect(calculateAgeInMonths(1, 1990)).toEqual(120);
     });
 
     it('should return the correct age in months for year < 100', () => {


### PR DESCRIPTION
Correct age calculation by only setting time after setting year so it doesn't rollback to to Dec 31st with the timezone diff.

Dates are hard!

## Summary

Provide a concise description of the changes made in this PR. Highlight the purpose, the problem being solved, or the feature being added. If applicable, link to any relevant issue(s).

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
