### PR TITLE
fix(frontend) React uses value instead of selected, fixes warning

### DIFF
--- a/frontend/app/components/age-picker-field.tsx
+++ b/frontend/app/components/age-picker-field.tsx
@@ -280,14 +280,14 @@ function AgePickerMonthField({
         aria-labelledby={ids.label}
         aria-required={required}
         className={cn(inputStyles.base, inputStyles.disabled, hasErrorMessage && inputStyles.error, className)}
-        defaultValue={defaultValue}
+        defaultValue={defaultValue ?? -1}
         disabled={disabled}
         id={ids.select}
         name={name}
         onChange={onChange}
         required={required}
       >
-        <option id={ids.optionUnselected} disabled hidden selected={defaultValue === undefined}>
+        <option id={ids.optionUnselected} disabled hidden value={-1}>
           {placeholder}
         </option>
         {months.map((month) => {

--- a/frontend/app/components/date-picker-field.tsx
+++ b/frontend/app/components/date-picker-field.tsx
@@ -269,13 +269,13 @@ function DatePickerMonthField({
         aria-labelledby={ids.label}
         aria-required={required}
         className={cn(inputStyles.base, inputStyles.disabled, hasErrorMessage && inputStyles.error, className)}
-        defaultValue={defaultValue}
+        defaultValue={defaultValue ?? -1}
         disabled={disabled}
         id={ids.select}
         name={name}
         required={required}
       >
-        <option id={ids.optionUnselected} disabled hidden selected={defaultValue === undefined}>
+        <option id={ids.optionUnselected} disabled hidden value={-1}>
           {placeholder}
         </option>
         {months.map((month) => {

--- a/frontend/tests/components/__snapshots__/date-picker-field.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/date-picker-field.test.tsx.snap
@@ -48,6 +48,8 @@ exports[`DatePickerField > should render date picker field component > expected 
               disabled=""
               hidden=""
               id="date-picker-id-month-option-unselected"
+              selected=""
+              value="-1"
             >
               common:date-picker.month.placeholder
             </option>
@@ -238,6 +240,7 @@ exports[`DatePickerField > should render date picker field component with defaul
               disabled=""
               hidden=""
               id="date-picker-id-month-option-unselected"
+              value="-1"
             >
               common:date-picker.month.placeholder
             </option>
@@ -474,6 +477,8 @@ exports[`DatePickerField > should render date picker field component with error 
               disabled=""
               hidden=""
               id="date-picker-id-month-option-unselected"
+              selected=""
+              value="-1"
             >
               common:date-picker.month.placeholder
             </option>
@@ -673,6 +678,8 @@ exports[`DatePickerField > should render date picker field component with help m
               disabled=""
               hidden=""
               id="date-picker-id-month-option-unselected"
+              selected=""
+              value="-1"
             >
               common:date-picker.month.placeholder
             </option>
@@ -880,6 +887,8 @@ exports[`DatePickerField > should render date picker field component with requir
               disabled=""
               hidden=""
               id="date-picker-id-month-option-unselected"
+              selected=""
+              value="-1"
             >
               common:date-picker.month.placeholder
             </option>


### PR DESCRIPTION
## Summary

Fixes console error from using `selected` on an option to selected the placeholder instead of using `value` on the `<select>`

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
