### PR TITLE
fix(frontend) Anchor link scroll focus to element

### DIFF
--- a/frontend/app/components/links.tsx
+++ b/frontend/app/components/links.tsx
@@ -129,7 +129,7 @@ export function AnchorLink({ anchorElementId, children, onClick, ...restProps }:
    */
   function handleOnSkipLinkClick(event: MouseEvent<HTMLAnchorElement>) {
     event.preventDefault();
-    scrollAndFocusFromAnchorLink(event.currentTarget.href);
+    scrollAndFocusToElement(anchorElementId);
     onClick?.(event);
   }
 
@@ -168,21 +168,15 @@ export function InlineLink({ className, children, file, hash, params, search, to
 }
 
 /**
- * Scrolls and focuses on the element identified by the anchor link's hash.
+ * Scrolls and focuses on the element identified.
  *
- * @param href - The anchor link URL.
+ * @param id - The element ID to scroll to and focus on.
  */
-function scrollAndFocusFromAnchorLink(href: string): void {
-  if (URL.canParse(href)) {
-    const { hash } = new URL(href);
+function scrollAndFocusToElement(id: string): void {
+  const targetElement = document.getElementById(id);
 
-    if (hash) {
-      const targetElement = document.getElementById(hash.replace('#', ''));
-
-      if (targetElement) {
-        targetElement.scrollIntoView({ behavior: 'smooth' });
-        targetElement.focus();
-      }
-    }
+  if (targetElement) {
+    targetElement.scrollIntoView({ behavior: 'smooth' });
+    targetElement.focus();
   }
 }


### PR DESCRIPTION
## Summary

React 19.1.0 changed how useId is generated with quotes instead of colons. This causes characters to be encoded when used in href. https://github.com/facebook/react/pull/32001

When using errorSummary with fields using the default useId() hook to generate the id, the quoted id is encoded and cannot find the element without first being decoded.

```
input-text-field-«Rhmlj5»-input
input-text-field-%C2%ABRhmlj5%C2%BB-input
```

Opted to simply use the `anchorElementId` to scroll and focus instead of including a decodeURIComponent in the existing function.



## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
