### PR TITLE
alters currency field config to hide empty decimals

### DIFF
--- a/frontend/app/components/currency-field.tsx
+++ b/frontend/app/components/currency-field.tsx
@@ -12,8 +12,9 @@ export interface CurrencyFieldProps extends Omit<InputFieldProps, 'type' | 'valu
   defaultValue?: string | number | null;
 }
 
-export function CurrencyField({ allowNegative = false, maxLength = 15, ...rest }: CurrencyFieldProps) {
+export function CurrencyField({ allowNegative = false, maxLength, ...rest }: CurrencyFieldProps) {
   const { i18n } = useTranslation(['common']);
+
   return (
     <NumericFormat
       customInput={InputField}
@@ -22,9 +23,9 @@ export function CurrencyField({ allowNegative = false, maxLength = 15, ...rest }
       allowNegative={allowNegative}
       decimalScale={2}
       decimalSeparator={i18n.language === 'fr' ? ',' : '.'}
-      fixedDecimalScale={true}
+      fixedDecimalScale={false}
       thousandsGroupStyle={'thousand'}
-      maxLength={maxLength}
+      maxLength={maxLength ?? (i18n.language === 'en' ? 15 : 16)}
       type="text"
       beforeInput={i18n.language === 'en' ? <span className="mr-1">$</span> : undefined}
       afterInput={i18n.language === 'fr' ? <span className="ml-1">$</span> : undefined}

--- a/frontend/app/routes/estimator/step-income.tsx
+++ b/frontend/app/routes/estimator/step-income.tsx
@@ -10,9 +10,9 @@ import type { Info, Route } from './+types/step-income';
 import type { MarriedIncome, MarriedIncomeForm, SingleIncome, SingleIncomeForm } from './@types';
 
 import { i18nRedirect } from '~/.server/utils/route-utils';
-import { CurrencyField } from '~/components/CurrencyField';
 import { Button } from '~/components/button';
 import { Collapsible } from '~/components/collapsible';
+import { CurrencyField } from '~/components/currency-field';
 import { FetcherErrorSummary } from '~/components/error-summary';
 import { PageTitle } from '~/components/page-title';
 import { useErrorTranslation } from '~/hooks/use-error-translation';

--- a/frontend/tests/components/currency-field.test.tsx
+++ b/frontend/tests/components/currency-field.test.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import { useTranslation } from 'react-i18next';
 import { describe, expect, it, vi } from 'vitest';
 
-import { CurrencyField } from '~/components/CurrencyField';
+import { CurrencyField } from '~/components/currency-field';
 
 vi.mock('~/i18n-routes', async (importActual) => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
@@ -25,17 +25,17 @@ vi.mock('~/i18n-routes', async (importActual) => {
 
 describe('CurrencyField', () => {
   it.each([
-    { lang: 'en', input: '12345', output: '12,345.00' },
+    { lang: 'en', input: '12345', output: '12,345' },
     { lang: 'en', input: '12,345.56', output: '12,345.56' },
     { lang: 'en', input: '12345.56', output: '12,345.56' },
     { lang: 'en', input: '.56', output: '.56' },
-    { lang: 'en', input: '56', output: '56.00' },
+    { lang: 'en', input: '56', output: '56' },
     { lang: 'en', input: 'bla bla', output: '' },
-    { lang: 'fr', input: '12345', output: '12 345,00' },
+    { lang: 'fr', input: '12345', output: '12 345' },
     { lang: 'fr', input: '12 345,56', output: '12 345,56' },
     { lang: 'fr', input: '12345,56', output: '12 345,56' },
     { lang: 'fr', input: ',56', output: ',56' },
-    { lang: 'fr', input: '56', output: '56,00' },
+    { lang: 'fr', input: '56', output: '56' },
     { lang: 'fr', input: 'bla bla', output: '' },
     { lang: 'fr', input: '12.34', output: '12,34' },
   ])('should render currency field component with correct value', ({ lang, input, output }) => {


### PR DESCRIPTION
## Summary

alter currency field behavior to not show .00 by default

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

