### PR TITLE
fixes income step currency field binding of previously posted values …

### DIFF
--- a/frontend/app/utils/string-utils.ts
+++ b/frontend/app/utils/string-utils.ts
@@ -3,7 +3,7 @@
  * @param input string represenation of a formatted decimal (examples: en:"1,234.56", fr:"1 234,56")
  * @param lang Format language (en or fr)
  * @returns string representation of the decimal without formatting (examples: "1234.56")
- */
+ *
 export function removeNumericFormatting(input: string, lang: Language): string {
   switch (lang) {
     case 'en': {
@@ -15,6 +15,24 @@ export function removeNumericFormatting(input: string, lang: Language): string {
       return output;
     }
   }
+}
+*/
+export function removeNumericFormatting(input: string | undefined): string {
+  if (input === undefined) return '';
+
+  const isFrench = input.includes(' ') || input.lastIndexOf(',') >= input.length - 3;
+  const isEnglish = input.indexOf(',') < input.length - 2 || input.lastIndexOf('.') >= input.length - 3;
+
+  if (isFrench) {
+    const output = input.replaceAll(' ', '').replaceAll(',', '.');
+    return output;
+  }
+  if (isEnglish) {
+    const output = input.replaceAll(',', '');
+    return output;
+  }
+
+  return input;
 }
 
 /**

--- a/frontend/tests/utils/string-utils.test.ts
+++ b/frontend/tests/utils/string-utils.test.ts
@@ -17,18 +17,33 @@ describe('string-utils', () => {
     });
 
     it.each([
-      { input: '.00', output: '.00', lang: 'en' },
-      { input: '0.00', output: '0.00', lang: 'en' },
-      { input: '1,234.56', output: '1234.56', lang: 'en' },
-      { input: '123.56', output: '123.56', lang: 'en' },
-      { input: ',00', output: '.00', lang: 'fr' },
-      { input: '0,00', output: '0.00', lang: 'fr' },
-      { input: '1 234,56', output: '1234.56', lang: 'fr' },
-      { input: '123,56', output: '123.56', lang: 'fr' },
+      { input: '.00', output: '.00' },
+      { input: '0.00', output: '0.00' },
+      { input: '1,234.56', output: '1234.56' },
+      { input: '123.56', output: '123.56' },
+      { input: ',00', output: '.00' },
+      { input: '0,00', output: '0.00' },
+      { input: '1 234,56', output: '1234.56' },
+      { input: '123,56', output: '123.56' },
+      { input: '1 234', output: '1234' },
+      { input: '1,234', output: '1234' },
+      { input: '1,234,567', output: '1234567' },
+      { input: '1 234 567', output: '1234567' },
+      { input: '1', output: '1' },
+      { input: '12', output: '12' },
+      { input: '123', output: '123' },
+      { input: '1.1', output: '1.1' },
+      { input: '1,1', output: '1.1' },
+      { input: '1,12', output: '1.12' },
+      { input: '1.12', output: '1.12' },
+      { input: '123.12', output: '123.12' },
+      { input: '123,12', output: '123.12' },
+      { input: '1,234.12', output: '1234.12' },
+      { input: '1 234,12', output: '1234.12' },
     ])(
-      'removeNumericFormatting should remove formatting from a formatted decimal string representation',
-      ({ input, lang, output }) => {
-        const str = removeNumericFormatting(input, lang as Language);
+      'removeNumericFormatting should remove formatting from a formatted decimal string representation ($input)',
+      ({ input, output }) => {
+        const str = removeNumericFormatting(input);
         expect(str).toBe(output);
       },
     );


### PR DESCRIPTION
…across language toggles

## Summary

fixes value formatting issue for currency fields on the income step page when assigning "previously submitted values" as the default value of a currency field using a different locale than what was used during the previous submit 

example : previous state: 1,234 (en) gets assigned to a currency field in the fr locale results in 1.234

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

