### PR TITLE
add return link to error pages

### DIFF
--- a/frontend/app/.server/locales/common-en.json
+++ b/frontend/app/.server/locales/common-en.json
@@ -176,6 +176,7 @@
     "version": "Version:"
   },
   "resource": "public/locales/public-en.json",
+  "return-to-dashboard": "Return to the estimator",
   "server-error": {
     "correlation-id": "<strong>Correlation ID:</strong> <span>{{correlationId}}</span>",
     "document-title": "Internal server error",

--- a/frontend/app/.server/locales/common-fr.json
+++ b/frontend/app/.server/locales/common-fr.json
@@ -180,6 +180,7 @@
     "version": "Version\u00a0:"
   },
   "resource": "public/locales/public-fr.json",
+  "return-to-dashboard": "Retourner à l'estimateur",
   "server-error": {
     "correlation-id": "<strong>ID de corrélation\u00a0:</strong> <span>{{correlationId}}</span>",
     "document-title": "Erreur interne du serveur",

--- a/frontend/app/components/error-boundaries.tsx
+++ b/frontend/app/components/error-boundaries.tsx
@@ -48,7 +48,7 @@ export function BilingualErrorBoundary({ actionData, error, loaderData, params }
           </div>
         </header>
         <main className="container">
-          <div className="grid grid-cols-1 gap-6 py-2.5 sm:grid-cols-2 sm:py-3.5">
+          <div className="mb-4 grid grid-cols-1 gap-6 py-2.5 sm:grid-cols-2 sm:py-3.5">
             <div id="english" lang="en">
               <PageTitle className="my-8">
                 <span>{en('common:server-error.page-title')}</span>
@@ -60,7 +60,7 @@ export function BilingualErrorBoundary({ actionData, error, loaderData, params }
               </PageTitle>
               <p className="mb-8 text-lg text-gray-500">{en('common:server-error.page-message')}</p>
               {isAppError(error) && (
-                <ul className="list-disc pl-10 text-gray-800">
+                <ul className="mb-4 list-disc pl-10 text-gray-800">
                   <li>
                     <Trans
                       t={en}
@@ -79,6 +79,13 @@ export function BilingualErrorBoundary({ actionData, error, loaderData, params }
                   </li>
                 </ul>
               )}
+              <AppLink
+                className="text-slate-700 underline hover:text-blue-700 focus:text-blue-700"
+                file="routes/index.tsx"
+                lang="en"
+              >
+                {en('common:return-to-dashboard')}
+              </AppLink>
             </div>
             <div id="french" lang="fr">
               <PageTitle className="my-8">
@@ -91,7 +98,7 @@ export function BilingualErrorBoundary({ actionData, error, loaderData, params }
               </PageTitle>
               <p className="mb-8 text-lg text-gray-500">{fr('common:server-error.page-message')}</p>
               {isAppError(error) && (
-                <ul className="list-disc pl-10 text-gray-800">
+                <ul className="mb-4 list-disc pl-10 text-gray-800">
                   <li>
                     <Trans
                       t={fr}
@@ -110,6 +117,13 @@ export function BilingualErrorBoundary({ actionData, error, loaderData, params }
                   </li>
                 </ul>
               )}
+              <AppLink
+                className="text-slate-700 underline hover:text-blue-700 focus:text-blue-700"
+                file="routes/index.tsx"
+                lang="fr"
+              >
+                {fr('common:return-to-dashboard')}
+              </AppLink>
             </div>
           </div>
         </main>
@@ -181,13 +195,20 @@ export function BilingualNotFound({ actionData, error, loaderData, params }: Rou
           </div>
         </header>
         <main className="container">
-          <div className="grid grid-cols-1 gap-6 py-2.5 sm:grid-cols-2 sm:py-3.5">
+          <div className="mb-4 grid grid-cols-1 gap-6 py-2.5 sm:grid-cols-2 sm:py-3.5">
             <div id="english" lang="en">
               <PageTitle className="my-8">
                 <span>{en('common:not-found.page-title')}</span>
                 <small className="block text-2xl font-normal text-neutral-500">{en('common:not-found.page-subtitle')}</small>
               </PageTitle>
               <p className="mb-8 text-lg text-gray-500">{en('common:not-found.page-message')}</p>
+              <AppLink
+                className="text-slate-700 underline hover:text-blue-700 focus:text-blue-700"
+                file="routes/index.tsx"
+                lang="en"
+              >
+                {en('common:return-to-dashboard')}
+              </AppLink>
             </div>
             <div id="french" lang="fr">
               <PageTitle className="my-8">
@@ -195,6 +216,13 @@ export function BilingualNotFound({ actionData, error, loaderData, params }: Rou
                 <small className="block text-2xl font-normal text-neutral-500">{fr('common:not-found.page-subtitle')}</small>
               </PageTitle>
               <p className="mb-8 text-lg text-gray-500">{fr('common:not-found.page-message')}</p>
+              <AppLink
+                className="text-slate-700 underline hover:text-blue-700 focus:text-blue-700"
+                file="routes/index.tsx"
+                lang="fr"
+              >
+                {fr('common:return-to-dashboard')}
+              </AppLink>
             </div>
           </div>
         </main>
@@ -253,7 +281,7 @@ export function UnilingualErrorBoundary({ actionData, error, loaderData, params 
       <body>
         <header className="border-b-[3px] border-slate-700 print:hidden">
           <div id="wb-bnr">
-            <div className="container flex items-center justify-between gap-6 py-2.5 sm:py-3.5">
+            <div className="container mb-4 flex items-center justify-between gap-6 py-2.5 sm:py-3.5">
               <AppLink to="https://canada.ca/">
                 <img
                   className="h-8 w-auto"
@@ -276,7 +304,7 @@ export function UnilingualErrorBoundary({ actionData, error, loaderData, params 
           </PageTitle>
           <p className="mb-8 text-lg text-gray-500">{t('common:server-error.page-message')}</p>
           {isAppError(error) && (
-            <ul className="list-disc pl-10 text-gray-800">
+            <ul className="mb-4 list-disc pl-10 text-gray-800">
               <li>
                 <Trans
                   i18nKey="common:server-error.error-code"
@@ -293,6 +321,9 @@ export function UnilingualErrorBoundary({ actionData, error, loaderData, params 
               </li>
             </ul>
           )}
+          <AppLink className="text-slate-700 underline hover:text-blue-700 focus:text-blue-700" file="routes/index.tsx">
+            {t('common:return-to-dashboard')}
+          </AppLink>
         </main>
         <footer id="wb-info" tabIndex={-1} className="mt-8 bg-stone-50 print:hidden">
           <div className="container flex items-center justify-end gap-6 py-2.5 sm:py-3.5">
@@ -353,12 +384,15 @@ export function UnilingualNotFound({ actionData, error, loaderData, params }: Ro
             </div>
           </div>
         </header>
-        <main className="container">
+        <main className="container mb-4">
           <PageTitle className="my-8">
             <span>{t('common:not-found.page-title')}</span>
             <small className="block text-2xl font-normal text-neutral-500">{t('common:not-found.page-subtitle')}</small>
           </PageTitle>
           <p className="mb-8 text-lg text-gray-500">{t('common:not-found.page-message')}</p>
+          <AppLink className="text-slate-700 underline hover:text-blue-700 focus:text-blue-700" file="routes/index.tsx">
+            {t('common:return-to-dashboard')}
+          </AppLink>
         </main>
         <footer id="wb-info" tabIndex={-1} className="bg-stone-50 print:hidden">
           <div className="container flex items-center justify-end gap-6 py-2.5 sm:py-3.5">

--- a/frontend/e2e/__snapshots__/not-found.spec.ts/Navigating-to-en-foo-renders-the-unilingual-404-page-2.txt
+++ b/frontend/e2e/__snapshots__/not-found.spec.ts/Navigating-to-en-foo-renders-the-unilingual-404-page-2.txt
@@ -14,3 +14,9 @@
   We're sorry you ended up here. Sometimes a page gets moved or deleted, but
   hopefully we can help you find what you're looking for.
 </p>
+<a
+  class="text-slate-700 underline hover:text-blue-700 focus:text-blue-700"
+  href="/en"
+  data-discover="true"
+  >Return to the estimator</a
+>

--- a/frontend/e2e/__snapshots__/not-found.spec.ts/Navigating-to-foo-renders-the-bilingual-404-page-2.txt
+++ b/frontend/e2e/__snapshots__/not-found.spec.ts/Navigating-to-foo-renders-the-bilingual-404-page-2.txt
@@ -1,4 +1,4 @@
-<div class="grid grid-cols-1 gap-6 py-2.5 sm:grid-cols-2 sm:py-3.5">
+<div class="mb-4 grid grid-cols-1 gap-6 py-2.5 sm:grid-cols-2 sm:py-3.5">
   <div id="english" lang="en">
     <div class="mt-10 mb-8">
       <h1
@@ -16,6 +16,13 @@
       We're sorry you ended up here. Sometimes a page gets moved or deleted, but
       hopefully we can help you find what you're looking for.
     </p>
+    <a
+      lang="en"
+      class="text-slate-700 underline hover:text-blue-700 focus:text-blue-700"
+      href="/en"
+      data-discover="true"
+      >Return to the estimator</a
+    >
   </div>
   <div id="french" lang="fr">
     <div class="mt-10 mb-8">
@@ -35,5 +42,12 @@
       page ait été déplacée ou supprimée. Heureusement, nous pouvons vous aider
       à trouver ce que vous cherchez.
     </p>
+    <a
+      lang="fr"
+      class="text-slate-700 underline hover:text-blue-700 focus:text-blue-700"
+      href="/fr"
+      data-discover="true"
+      >Retourner à l'estimateur</a
+    >
   </div>
 </div>

--- a/frontend/tests/components/__snapshots__/error-boundaries.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/error-boundaries.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`error-boundaries > BilingualErrorBoundary > should correctly render the
         class="container"
       >
         <div
-          class="grid grid-cols-1 gap-6 py-2.5 sm:grid-cols-2 sm:py-3.5"
+          class="mb-4 grid grid-cols-1 gap-6 py-2.5 sm:grid-cols-2 sm:py-3.5"
         >
           <div
             id="english"
@@ -76,6 +76,14 @@ exports[`error-boundaries > BilingualErrorBoundary > should correctly render the
             >
               common:server-error.page-message
             </p>
+            <a
+              class="text-slate-700 underline hover:text-blue-700 focus:text-blue-700"
+              data-discover="true"
+              href="/en"
+              lang="en"
+            >
+              common:return-to-dashboard
+            </a>
           </div>
           <div
             id="french"
@@ -104,6 +112,14 @@ exports[`error-boundaries > BilingualErrorBoundary > should correctly render the
             >
               common:server-error.page-message
             </p>
+            <a
+              class="text-slate-700 underline hover:text-blue-700 focus:text-blue-700"
+              data-discover="true"
+              href="/fr"
+              lang="fr"
+            >
+              common:return-to-dashboard
+            </a>
           </div>
         </div>
       </main>
@@ -209,7 +225,7 @@ exports[`error-boundaries > BilingualErrorBoundary > should correctly render the
         class="container"
       >
         <div
-          class="grid grid-cols-1 gap-6 py-2.5 sm:grid-cols-2 sm:py-3.5"
+          class="mb-4 grid grid-cols-1 gap-6 py-2.5 sm:grid-cols-2 sm:py-3.5"
         >
           <div
             id="english"
@@ -239,7 +255,7 @@ exports[`error-boundaries > BilingualErrorBoundary > should correctly render the
               common:server-error.page-message
             </p>
             <ul
-              class="list-disc pl-10 text-gray-800"
+              class="mb-4 list-disc pl-10 text-gray-800"
             >
               <li>
                 {"key":"common:server-error.error-code","options":{"values":{"errorCode":"UNC-0000"}}}
@@ -248,6 +264,14 @@ exports[`error-boundaries > BilingualErrorBoundary > should correctly render the
                 {"key":"common:server-error.correlation-id","options":{"values":{"correlationId":"XX-000000"}}}
               </li>
             </ul>
+            <a
+              class="text-slate-700 underline hover:text-blue-700 focus:text-blue-700"
+              data-discover="true"
+              href="/en"
+              lang="en"
+            >
+              common:return-to-dashboard
+            </a>
           </div>
           <div
             id="french"
@@ -277,7 +301,7 @@ exports[`error-boundaries > BilingualErrorBoundary > should correctly render the
               common:server-error.page-message
             </p>
             <ul
-              class="list-disc pl-10 text-gray-800"
+              class="mb-4 list-disc pl-10 text-gray-800"
             >
               <li>
                 {"key":"common:server-error.error-code","options":{"values":{"errorCode":"UNC-0000"}}}
@@ -286,6 +310,14 @@ exports[`error-boundaries > BilingualErrorBoundary > should correctly render the
                 {"key":"common:server-error.correlation-id","options":{"values":{"correlationId":"XX-000000"}}}
               </li>
             </ul>
+            <a
+              class="text-slate-700 underline hover:text-blue-700 focus:text-blue-700"
+              data-discover="true"
+              href="/fr"
+              lang="fr"
+            >
+              common:return-to-dashboard
+            </a>
           </div>
         </div>
       </main>
@@ -386,7 +418,7 @@ exports[`error-boundaries > BilingualNotFound > should correctly render the bili
         class="container"
       >
         <div
-          class="grid grid-cols-1 gap-6 py-2.5 sm:grid-cols-2 sm:py-3.5"
+          class="mb-4 grid grid-cols-1 gap-6 py-2.5 sm:grid-cols-2 sm:py-3.5"
         >
           <div
             id="english"
@@ -415,6 +447,14 @@ exports[`error-boundaries > BilingualNotFound > should correctly render the bili
             >
               common:not-found.page-message
             </p>
+            <a
+              class="text-slate-700 underline hover:text-blue-700 focus:text-blue-700"
+              data-discover="true"
+              href="/en"
+              lang="en"
+            >
+              common:return-to-dashboard
+            </a>
           </div>
           <div
             id="french"
@@ -443,6 +483,14 @@ exports[`error-boundaries > BilingualNotFound > should correctly render the bili
             >
               common:not-found.page-message
             </p>
+            <a
+              class="text-slate-700 underline hover:text-blue-700 focus:text-blue-700"
+              data-discover="true"
+              href="/fr"
+              lang="fr"
+            >
+              common:return-to-dashboard
+            </a>
           </div>
         </div>
       </main>
@@ -512,7 +560,7 @@ exports[`error-boundaries > UnilingualErrorBoundary > should correctly render th
           id="wb-bnr"
         >
           <div
-            class="container flex items-center justify-between gap-6 py-2.5 sm:py-3.5"
+            class="container mb-4 flex items-center justify-between gap-6 py-2.5 sm:py-3.5"
           >
             <a
               href="https://canada.ca/"
@@ -555,6 +603,13 @@ exports[`error-boundaries > UnilingualErrorBoundary > should correctly render th
         >
           common:server-error.page-message
         </p>
+        <a
+          class="text-slate-700 underline hover:text-blue-700 focus:text-blue-700"
+          data-discover="true"
+          href="/en"
+        >
+          common:return-to-dashboard
+        </a>
       </main>
       <footer
         class="mt-8 bg-stone-50 print:hidden"
@@ -612,7 +667,7 @@ exports[`error-boundaries > UnilingualErrorBoundary > should correctly render th
           id="wb-bnr"
         >
           <div
-            class="container flex items-center justify-between gap-6 py-2.5 sm:py-3.5"
+            class="container mb-4 flex items-center justify-between gap-6 py-2.5 sm:py-3.5"
           >
             <a
               href="https://canada.ca/"
@@ -656,7 +711,7 @@ exports[`error-boundaries > UnilingualErrorBoundary > should correctly render th
           common:server-error.page-message
         </p>
         <ul
-          class="list-disc pl-10 text-gray-800"
+          class="mb-4 list-disc pl-10 text-gray-800"
         >
           <li>
             {"key":"common:server-error.error-code","options":{"values":{"errorCode":"UNC-0000"}}}
@@ -665,6 +720,13 @@ exports[`error-boundaries > UnilingualErrorBoundary > should correctly render th
             {"key":"common:server-error.correlation-id","options":{"values":{"correlationId":"XX-000000"}}}
           </li>
         </ul>
+        <a
+          class="text-slate-700 underline hover:text-blue-700 focus:text-blue-700"
+          data-discover="true"
+          href="/en"
+        >
+          common:return-to-dashboard
+        </a>
       </main>
       <footer
         class="mt-8 bg-stone-50 print:hidden"
@@ -740,7 +802,7 @@ exports[`error-boundaries > UnilingualNotFound > should correctly render the uni
         </div>
       </header>
       <main
-        class="container"
+        class="container mb-4"
       >
         <div
           class="mt-10 mb-8"
@@ -765,6 +827,13 @@ exports[`error-boundaries > UnilingualNotFound > should correctly render the uni
         >
           common:not-found.page-message
         </p>
+        <a
+          class="text-slate-700 underline hover:text-blue-700 focus:text-blue-700"
+          data-discover="true"
+          href="/en"
+        >
+          common:return-to-dashboard
+        </a>
       </main>
       <footer
         class="bg-stone-50 print:hidden"

--- a/performance-tests/package-lock.json
+++ b/performance-tests/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "load-tests",
+  "name": "performance-tests",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Summary

adds "return to estimator" links to error pages

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>
![image](https://github.com/user-attachments/assets/103aab03-02d0-4687-9dbf-f562b139f5d4)

