### PR TITLE
release(gitops) Enable public ingress

### DIFF
--- a/gitops/prod/overlay/ingresses.yaml
+++ b/gitops/prod/overlay/ingresses.yaml
@@ -1,22 +1,22 @@
-# apiVersion: networking.k8s.io/v1
-# kind: Ingress
-# metadata:
-#   name: cdb-estimator-frontend-public
-#   labels:
-#     app.kubernetes.io/name: cdb-estimator-frontend-public
-# spec:
-#   ingressClassName: nginx
-#   rules:
-#     - host: estimateurpcph-cdbestimator.service.canada.ca
-#       http:
-#         paths:
-#           - path: /
-#             pathType: Prefix
-#             backend:
-#               service:
-#                 name: cdb-estimator-frontend
-#                 port:
-#                   name: http
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cdb-estimator-frontend-public
+  labels:
+    app.kubernetes.io/name: cdb-estimator-frontend-public
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: estimateurpcph-cdbestimator.service.canada.ca
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: cdb-estimator-frontend
+                port:
+                  name: http
 
 ---
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
## Summary

Everything is running in production behind an internal url. This is to turn on public traffic to the system.